### PR TITLE
Update To Later Version Of Chef Client

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,5 @@
 desc 'Define default task'
-task default: [:cookstyle, :foodcritic]
+task default: [:cookstyle, :foodcritic, :kitchentest]
 
 desc 'Run cookstyle'
 task :cookstyle do
@@ -9,6 +9,11 @@ end
 desc 'Run foodcritic in current directory'
 task :foodcritic do
   sh 'foodcritic . --tags ~FC078'
+end
+
+desc 'Run kitchen test in current directory'
+task :kitchentest do
+  sh 'kitchen test'
 end
 
 desc 'Berks upload mywrapper_chef_client_updater cookbook'
@@ -31,5 +36,5 @@ task remove_test: [:deletenode_test, :deleteclient_test]
 
 desc 'Bootstrap test server'
 task bootstrap_test: [:upload] do
-  sh 'knife bootstrap 192.168.1.234 -E test -N testserver -r mywrapper_chef_client_updater --sudo --ssh-user test --ssh-password test --use-sudo-password --bootstrap-version 14.3.37'
+  sh 'knife bootstrap 192.168.1.234 -N testserver -r mywrapper_chef_client_updater --sudo --ssh-user test --ssh-password test --use-sudo-password --bootstrap-version 14.4.56'
 end

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,2 +1,2 @@
 # manage chef client
-default['chef_client_updater']['version'] = '14.3.37'
+default['chef_client_updater']['version'] = '14.4.56'

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,10 +4,10 @@ maintainer_email 'alinkous+support@gmail.com'
 license 'All Rights Reserved'
 description 'Installs/Configures mywrapper_chef_client_updater'
 long_description 'Installs/Configures mywrapper_chef_client_updater'
-version '0.5.0'
+version '0.6.0'
 supports 'centos'
 chef_version '>= 12.19' if respond_to?(:chef_version)
 issues_url 'https://github.com/gryte/mywrapper_chef_client_updater/issues'
 source_url 'https://github.com/gryte/mywrapper_chef_client_updater'
 
-depends 'chef_client_updater', '~> 3.3.2'
+depends 'chef_client_updater', '~> 3.5.0'

--- a/test/integration/default/default_test.rb
+++ b/test/integration/default/default_test.rb
@@ -8,5 +8,5 @@
 # chef client is installed with version 14.0.202
 describe package('chef') do
   it { should be_installed }
-  its('version') { should eq '14.3.37-1.el7' }
+  its('version') { should eq '14.4.56-1.el7' }
 end


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Bump versions
  - metadata version
  - depends version
  - rakefile chef client install
- update cookbook attributes
  - take latest version of chef client
- update tests
  - bump version check
- remove environment flag in rake bootstrap command
  - this is controlled by version contraints in the env file
- Add kitchen test as default rake task

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
- n/a

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to keep the infrastructure up to date with the latest chef client release.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
The local kitchen test passed without errors.

## Screenshots (if appropriate):
- n/a

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
